### PR TITLE
Fix | sign action button shift in header main layout

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,7 +21,16 @@
       </nav>
     </div>
 
-    <button><a href="login">Sign in</a></button>
+    @auth
+      <a class="dropdown-item" href="#" onclick="event.preventDefault(); document.getElementById('logoutForm').submit();">
+        {{ __('Sign Out') }}
+      </a>
+      <form id="logoutForm" action="{{ route('logout') }}" method="POST" class="d-none hidden">
+    @endauth
+
+    @guest
+      <button><a href="login">Sign in</a></button>
+    @endguest
   </header>
 
   <ng-view>


### PR DESCRIPTION
### Overview

As I said before, the significant refactor of our client side code introduced a lot of bugs that caused crucial features that were  previously working as expected not working anymore. Hence, We aimed on fixing the user auth's workflow and the end of this flow (which is the sign out action) was not reachable for the users.

### Changes made

- add `auth` and `guest` blade `directives` to change both button text content and `src` attribute of the `a HTML element` inside the button

This resolves the user auth workflow issues and ensures that the sign-out action is now reachable for users.